### PR TITLE
Add git and GitPython to doc builder

### DIFF
--- a/docbuilder/apt-requirements.txt
+++ b/docbuilder/apt-requirements.txt
@@ -2,3 +2,4 @@ python3.10
 python3.10-venv
 python3-pil
 python3-pil.imagetk
+git

--- a/docbuilder/python-requirements.txt
+++ b/docbuilder/python-requirements.txt
@@ -6,3 +6,4 @@ sphinxcontrib-confluencebuilder
 numpy>=1.22.3
 matplotlib>=3.5.1
 myst-parser
+GitPython


### PR DESCRIPTION
So we can change `conf.py` to look at tags if desired to determine the version to display. Working locally.