### PR TITLE
Update python-requirements.txt

### DIFF
--- a/docbuilder/python-requirements.txt
+++ b/docbuilder/python-requirements.txt
@@ -8,5 +8,4 @@ sphinx
 sphinx-autoapi
 sphinx-jsonschema!=1.19.0
 sphinx-rtd-theme
-sphinx_rtd_theme
 sphinxcontrib-confluencebuilder


### PR DESCRIPTION
## changes
- add:
  - m2r2
  - sphinx-autoapi
  - sphinx-jsonschema 
    - do not use 1.19.0 due to https://github.com/lnoor/sphinx-jsonschema/issues/76. Fixed by 1.19.1. 
  - sphinx-rtd-theme
- run `sort` on file
- change `Sphinx`→`sphinx`. PyPI is case insensitive and is easier on sorting